### PR TITLE
Fix battlegear inventory voiding when clicking on item

### DIFF
--- a/src/main/java/mods/battlegear2/mixins/early/MixinInventoryPlayer.java
+++ b/src/main/java/mods/battlegear2/mixins/early/MixinInventoryPlayer.java
@@ -111,6 +111,7 @@ public abstract class MixinInventoryPlayer implements IInventoryPlayerBattle {
                     }
                 }
                 cir.setReturnValue(targetStack);
+                return;
             }
             cir.setReturnValue(null);
         }


### PR DESCRIPTION
It was still able to hit `cir.setReturnValue(null)` after setting the return value, and would thus always return null.
Returning early fixes that, alternatively replacing `cir.setReturnValue(null)` with `cir.cancel()` should also return null in all the same cases and won't overwrite the earlier return value. Whatever floats your boat :)

Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/14720