### PR TITLE
Change to mixin to disable blockpick when in creative and battle mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1704751096
+//version: 1705357285
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -122,6 +122,7 @@ propertyDefaultIfUnset("modrinthProjectId", "")
 propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnset("curseForgeProjectId", "")
 propertyDefaultIfUnset("curseForgeRelations", "")
+propertyDefaultIfUnset("versionPattern", "")
 propertyDefaultIfUnset("minimizeShadowedDependencies", true)
 propertyDefaultIfUnset("relocateShadowedDependencies", true)
 // Deprecated properties (kept for backwards compat)
@@ -370,6 +371,7 @@ catch (Exception ignored) {
 // Pulls version first from the VERSION env and then git tag
 String identifiedVersion
 String versionOverride = System.getenv("VERSION") ?: null
+boolean checkVersion = false
 try {
     // Produce a version based on the tag, or for branches something like 0.2.2-configurable-maven-and-extras.38+43090270b6-dirty
     if (versionOverride == null) {
@@ -388,6 +390,8 @@ try {
             }
         } else if (isDirty) {
             identifiedVersion += "-${branchName}+${gitDetails.gitHash}-dirty"
+        } else {
+            checkVersion = true
         }
     } else {
         identifiedVersion = versionOverride
@@ -409,6 +413,8 @@ ext {
 
 if (identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
+} else if (checkVersion && versionPattern && !(identifiedVersion ==~ versionPattern)) {
+    throw new GradleException("Invalid version: '$identifiedVersion' does not match version pattern '$versionPattern'")
 }
 
 group = "com.github.GTNewHorizons"
@@ -428,18 +434,31 @@ minecraft {
         for (f in replaceGradleTokenInFile.split(',')) {
             tagReplacementFiles.add f
         }
+        out.style(Style.Info).text('replaceGradleTokenInFile is deprecated! Consider using generateGradleTokenClass.').println()
     }
     if (gradleTokenModId) {
-        injectedTags.put gradleTokenModId, modId
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModId, modId
+        } else {
+            out.style(Style.Failure).text('gradleTokenModId is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenModName) {
-        injectedTags.put gradleTokenModName, modName
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenModName, modName
+        } else {
+            out.style(Style.Failure).text('gradleTokenModName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (gradleTokenVersion) {
         injectedTags.put gradleTokenVersion, modVersion
     }
     if (gradleTokenGroupName) {
-        injectedTags.put gradleTokenGroupName, modGroup
+        if (replaceGradleTokenInFile) {
+            injectedTags.put gradleTokenGroupName, modGroup
+        } else {
+            out.style(Style.Failure).text('gradleTokenGroupName is deprecated! The field will no longer be generated.').println()
+        }
     }
     if (enableGenericInjection.toBoolean()) {
         injectMissingGenerics.set(true)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.5-GTNH:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.8-GTNH:dev') {transitive = false}
     compileOnly('curse.maven:dynamic-lights-227874:2337326')
 }

--- a/src/main/java/mods/battlegear2/asm/loader/BattlegearLoadingPlugin.java
+++ b/src/main/java/mods/battlegear2/asm/loader/BattlegearLoadingPlugin.java
@@ -68,6 +68,7 @@ public final class BattlegearLoadingPlugin implements IEarlyMixinLoader, IFMLLoa
             mixins.add("MixinItemRenderer");
             mixins.add("MixinModelBiped");
             mixins.add("MixinNetHandlerPlayClient");
+            mixins.add("MixinForgeHooks");
         }
         return mixins;
     }

--- a/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
+++ b/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
@@ -26,7 +26,6 @@ import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 import net.minecraftforge.client.event.FOVUpdateEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
-import net.minecraftforge.client.event.MouseEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.client.event.RenderPlayerEvent;
@@ -59,7 +58,6 @@ import mods.battlegear2.client.model.QuiverModel;
 import mods.battlegear2.client.utils.BattlegearRenderHelper;
 import mods.battlegear2.enchantments.BaseEnchantment;
 import mods.battlegear2.items.ItemWeapon;
-import mods.battlegear2.packet.PickBlockPacket;
 import mods.battlegear2.utils.BattlegearConfig;
 
 public final class BattlegearClientEvents {

--- a/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
+++ b/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
@@ -296,48 +296,6 @@ public final class BattlegearClientEvents {
     }
 
     /**
-     * Fixes pick block
-     */
-    @SubscribeEvent(priority = EventPriority.HIGHEST)
-    public void replacePickBlock(MouseEvent event) {
-        if (event.buttonstate) {
-            Minecraft mc = FMLClientHandler.instance().getClient();
-            if (mc.thePlayer != null) {
-                if (event.button - 100 == mc.gameSettings.keyBindPickBlock.getKeyCode()) {
-                    event.setCanceled(true);
-                    if (!((IBattlePlayer) mc.thePlayer).battlegear2$isBattlemode()) {
-                        boolean isCreative = mc.thePlayer.capabilities.isCreativeMode;
-                        ItemStack stack = getItemFromPointedAt(mc.objectMouseOver, mc.thePlayer);
-                        if (stack != null) {
-                            int k = -1;
-                            ItemStack temp;
-                            for (int slot = 0; slot < MAIN_INV; slot++) {
-                                temp = mc.thePlayer.inventory.getStackInSlot(slot);
-                                if (temp != null && stack.isItemEqual(temp)
-                                        && ItemStack.areItemStackTagsEqual(stack, temp)) {
-                                    k = slot;
-                                    break;
-                                }
-                            }
-                            if (isCreative && k == -1) {
-                                k = mc.thePlayer.inventory.getFirstEmptyStack();
-                                if (k < 0 || k >= MAIN_INV) {
-                                    k = mc.thePlayer.inventory.currentItem;
-                                }
-                            }
-                            if (k >= 0 && k < MAIN_INV) {
-                                mc.thePlayer.inventory.currentItem = k;
-                                Battlegear.packetHandler
-                                        .sendPacketToServer(new PickBlockPacket(stack, k).generatePacket());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
      * Equivalent code to the creative pick block
      *
      * @param target The client target vector

--- a/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
+++ b/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
@@ -21,7 +21,7 @@ public class MixinForgeHooks {
     @Inject(method = "onPickBlock", at = @At(value = "HEAD"), cancellable = true)
     private static void battlegear2$onPickBlock(MovingObjectPosition target, EntityPlayer player, World world,
             CallbackInfoReturnable<Boolean> cir) {
-        if (player.capabilities.isCreativeMode && ((IBattlePlayer) player).battlegear2$isBattlemode()) {
+        if (((IBattlePlayer) player).battlegear2$isBattlemode()) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
+++ b/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
@@ -1,26 +1,27 @@
 package mods.battlegear2.mixins.early;
 
-
-import mods.battlegear2.api.core.IBattlePlayer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import mods.battlegear2.api.core.IBattlePlayer;
+
 @Mixin(value = ForgeHooks.class, remap = false)
 public class MixinForgeHooks {
-
 
     /**
      * Exit early if in creative mode and in battle mode
      */
     @Inject(method = "onPickBlock", at = @At(value = "HEAD"), cancellable = true)
-    private static void battlegear2$onPickBlock(MovingObjectPosition target, EntityPlayer player, World world, CallbackInfoReturnable<Boolean> cir){
-        if (player.capabilities.isCreativeMode && ((IBattlePlayer) player).battlegear2$isBattlemode()){
+    private static void battlegear2$onPickBlock(MovingObjectPosition target, EntityPlayer player, World world,
+            CallbackInfoReturnable<Boolean> cir) {
+        if (player.capabilities.isCreativeMode && ((IBattlePlayer) player).battlegear2$isBattlemode()) {
             cir.setReturnValue(false);
         }
     }

--- a/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
+++ b/src/main/java/mods/battlegear2/mixins/early/MixinForgeHooks.java
@@ -1,0 +1,28 @@
+package mods.battlegear2.mixins.early;
+
+
+import mods.battlegear2.api.core.IBattlePlayer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+import net.minecraftforge.common.ForgeHooks;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ForgeHooks.class, remap = false)
+public class MixinForgeHooks {
+
+
+    /**
+     * Exit early if in creative mode and in battle mode
+     */
+    @Inject(method = "onPickBlock", at = @At(value = "HEAD"), cancellable = true)
+    private static void battlegear2$onPickBlock(MovingObjectPosition target, EntityPlayer player, World world, CallbackInfoReturnable<Boolean> cir){
+        if (player.capabilities.isCreativeMode && ((IBattlePlayer) player).battlegear2$isBattlemode()){
+            cir.setReturnValue(false);
+        }
+    }
+
+}


### PR DESCRIPTION
Dont really see the point of  `sendPacketToServer(new PickBlockPacket(stack, k).generatePacket());` when all that packet does is

```java
if (player != null && !((IBattlePlayer) player).battlegear2$isBattlemode()) {
            try {
                slot = inputStream.readInt();
                stack = ByteBufUtils.readItemStack(inputStream);
            } catch (Exception e) {
                e.printStackTrace();
                return;
            }
            if (IInventoryPlayerBattle.isValidSwitch(slot)) {
                player.inventory.currentItem = slot;
                if (player.capabilities.isCreativeMode
                        && !ItemStack.areItemStacksEqual(stack, player.getCurrentEquippedItem())) {
                    BattlegearUtils.setPlayerCurrentItem(player, stack);
                }
                if (player instanceof EntityPlayerMP)
                    Battlegear.packetHandler.sendPacketToPlayer(this.generatePacket(), (EntityPlayerMP) player);
            }
        }
```


`setPlayerCurrentItem` boils down to

offset = 0
```java
((IInventoryPlayerBattle) (player.inventory))
                .battlegear2$setInventorySlotContents(player.inventory.currentItem + offset, stack, false);
```

which is 

```java
@Override
    public void battlegear2$setInventorySlotContents(int index, ItemStack stack, boolean changed) {
        if (index >= OFFSET) {
            battlegear2$isDirty = changed;
            battlegear2$extraItems[index - OFFSET] = stack;
        } else {
            this.setInventorySlotContents(index, stack);
        }
    }
```

So it looks like its impossible for index to be greater than or equal to OFFSET