### PR TITLE
Stop registering buttons that are disabled

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 // Add your dependencies here
 
 dependencies {
-    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.9-GTNH:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev') {transitive = false}
     compileOnly('curse.maven:dynamic-lights-227874:2337326')
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ channel = stable
 mappingsVersion = 12
 
 # Defines other MCP mappings for dependency deobfuscation.
-remoteMappings = https://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
+remoteMappings = https\://raw.githubusercontent.com/MinecraftForge/FML/1.7.10/conf/
 
 # Select a default username for testing your mod. You can always override this per-run by running
 # `./gradlew runClient --username=AnotherPlayer`, or configuring this command in your IDE.
@@ -60,6 +60,9 @@ gradleTokenModId =
 
 # [DEPRECATED] Mod name replacement token.
 gradleTokenModName =
+
+# [DEPRECATED] Mod Group replacement token.
+gradleTokenGroupName =
 
 # [DEPRECATED]
 # Multiple source files can be defined here by providing a comma-separated list: Class1.java,Class2.java,Class3.java
@@ -123,7 +126,7 @@ includeWellKnownRepositories = true
 usesMavenPublishing = true
 
 # Maven repository to publish the mod to.
-# mavenPublishUrl = https://nexus.gtnewhorizons.com/repository/releases/
+# mavenPublishUrl = https\://nexus.gtnewhorizons.com/repository/releases/
 
 # Publishing to Modrinth requires you to set the MODRINTH_TOKEN environment variable to your current Modrinth API token.
 #
@@ -187,5 +190,3 @@ curseForgeRelations =
 # This is meant to be set in $HOME/.gradle/gradle.properties.
 # ideaCheckSpotlessOnBuild = true
 
-# Non-GTNH properties
-gradleTokenGroupName = 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.8'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.19'
 }
 
 

--- a/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
+++ b/src/main/java/mods/battlegear2/client/BattlegearClientEvents.java
@@ -435,8 +435,7 @@ public final class BattlegearClientEvents {
     @SubscribeEvent(priority = EventPriority.LOW)
     public void postInitGui(GuiScreenEvent.InitGuiEvent.Post event) {
         if (Battlegear.battlegearEnabled && event.gui instanceof InventoryEffectRenderer) {
-            if (!ClientProxy.tconstructEnabled
-                    || FMLClientHandler.instance().getClientPlayerEntity().capabilities.isCreativeMode) {
+            if (!ClientProxy.tconstructEnabled) {
                 onOpenGui(
                         event.buttonList,
                         guessGuiLeft((InventoryEffectRenderer) event.gui) - 30,


### PR DESCRIPTION
The two buttons which are added in postInitGui aren't being rendered whenever TiC is present as seen [here](https://github.com/GTNewHorizons/Battlegear2/blob/056b6f37f4404e37a0fa4d38eda607c680ed39d5/src/main/java/mods/battlegear2/client/gui/controls/GuiPlaceableButton.java#L65), but they are still being added to the button list of the creative inv which causes them to register clicks despite being invisible.
Their location currently conflicts with SU's sidebar which can be addressed separately, but removing the invisible buttons will work for now.

Closes https://github.com/GTNewHorizons/ServerUtilities/issues/56