### PR TITLE
fix mystery arrows giving diamonds on player hit

### DIFF
--- a/src/main/java/mods/battlegear2/items/arrows/EntityLoveArrow.java
+++ b/src/main/java/mods/battlegear2/items/arrows/EntityLoveArrow.java
@@ -54,7 +54,7 @@ public class EntityLoveArrow extends AbstractMBArrow {
             } else if (entityHit instanceof EntityCreature) {
                 ((EntityCreature) entityHit).setTarget(null);
                 if (((EntityCreature) entityHit).getHeldItem() == null) {
-                    entityHit.setCurrentItemOrArmor(0, new ItemStack(ItemMBArrow.component[5]));
+                    entityHit.setCurrentItemOrArmor(0, new ItemStack(ItemMBArrow.component[7]));
                 }
                 setDead();
                 return true;
@@ -70,7 +70,7 @@ public class EntityLoveArrow extends AbstractMBArrow {
                 if (!((IBattlePlayer) entityHit).battlegear2$isBattlemode())
                     ((EntityPlayer) entityHit).inventory.setInventorySlotContents(
                             ((EntityPlayer) entityHit).inventory.currentItem,
-                            new ItemStack(ItemMBArrow.component[5]));
+                            new ItemStack(ItemMBArrow.component[7]));
                 setDead();
                 return true;
             }

--- a/src/main/java/mods/battlegear2/items/arrows/EntityLoveArrow.java
+++ b/src/main/java/mods/battlegear2/items/arrows/EntityLoveArrow.java
@@ -6,13 +6,13 @@ import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeHooks;
 
 import mods.battlegear2.api.core.IBattlePlayer;
-import mods.battlegear2.items.ItemMBArrow;
 
 /**
  * An arrow which deals weird effects on living entities
@@ -54,7 +54,7 @@ public class EntityLoveArrow extends AbstractMBArrow {
             } else if (entityHit instanceof EntityCreature) {
                 ((EntityCreature) entityHit).setTarget(null);
                 if (((EntityCreature) entityHit).getHeldItem() == null) {
-                    entityHit.setCurrentItemOrArmor(0, new ItemStack(ItemMBArrow.component[7]));
+                    entityHit.setCurrentItemOrArmor(0, new ItemStack(Items.cookie));
                 }
                 setDead();
                 return true;
@@ -70,7 +70,7 @@ public class EntityLoveArrow extends AbstractMBArrow {
                 if (!((IBattlePlayer) entityHit).battlegear2$isBattlemode())
                     ((EntityPlayer) entityHit).inventory.setInventorySlotContents(
                             ((EntityPlayer) entityHit).inventory.currentItem,
-                            new ItemStack(ItemMBArrow.component[7]));
+                            new ItemStack(Items.cookie));
                 setDead();
                 return true;
             }


### PR DESCRIPTION
index shifted by 2 when new arrows were added,but index wasn't updated for mystery arrow
it was supposed to give the crafting component which was a cookie,but ended up giving the component for a piercing arrow, which is a diamond

ice arrow added : 
https://github.com/GTNewHorizons/Battlegear2/commit/7e8dcdb2811f1c55f892925756f4924e2e65a529#diff-eccef2bb78d5f9075dbbc3ef03b5ba2b20c6ddd7c4726da3e099aa7ffeb7bef3R23

holy arrow added: 
https://github.com/GTNewHorizons/Battlegear2/commit/f3197729ba656ed7b8c0959ddbe298795605c959#diff-eccef2bb78d5f9075dbbc3ef03b5ba2b20c6ddd7c4726da3e099aa7ffeb7bef3R23

after change it gives a cookie again