### PR TITLE
Fix Mixin log warning about max shift limit

### DIFF
--- a/src/main/java/mods/battlegear2/mixins/early/MixinInventoryPlayer.java
+++ b/src/main/java/mods/battlegear2/mixins/early/MixinInventoryPlayer.java
@@ -211,10 +211,9 @@ public abstract class MixinInventoryPlayer implements IInventoryPlayerBattle {
     @Inject(
             method = "readFromNBT",
             at = @At(
-                    value = "INVOKE",
+                    value = "INVOKE_ASSIGN",
                     target = "Lnet/minecraft/item/ItemStack;loadItemStackFromNBT(Lnet/minecraft/nbt/NBTTagCompound;)Lnet/minecraft/item/ItemStack;",
-                    shift = At.Shift.BY,
-                    by = 2),
+                    shift = At.Shift.AFTER),
             locals = LocalCapture.CAPTURE_FAILHARD)
     private void battlegear2$readFromNBT$setItems(NBTTagList p_70443_1_, CallbackInfo ci, int i,
             NBTTagCompound nbttagcompound, int j, ItemStack stack) {

--- a/src/main/resources/mixins.battlegear2.early.json
+++ b/src/main/resources/mixins.battlegear2.early.json
@@ -5,9 +5,6 @@
   "refmap": "mixins.battlegear2.refmap.json",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
-  "injectors": {
-    "maxShiftBy": 2
-  },
   "mixins": [],
   "client": [],
   "server": []

--- a/src/main/resources/mixins.battlegear2.early.json
+++ b/src/main/resources/mixins.battlegear2.early.json
@@ -5,6 +5,9 @@
   "refmap": "mixins.battlegear2.refmap.json",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
+  "injectors": {
+    "maxShiftBy": 2
+  },
   "mixins": [],
   "client": [],
   "server": []


### PR DESCRIPTION
Fixes this log message about the max shift limit

`
@Inject(@At("INVOKE")) Shift.BY=2 on mixins.battlegear2.early.json:MixinInventoryPlayer from mod battlegear2::handler$zmb000$battlegear2$readFromNBT$setItems exceeds the maximum allowed value: 0. Increase the value of maxShiftBy to suppress this warning.
`