### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/battlegear2/lang/en_US.lang
+++ b/src/main/resources/assets/battlegear2/lang/en_US.lang
@@ -30,6 +30,7 @@ item.battlegear2:heraldric.name=Heraldic Icon
 item.battlegear2:chain.name=Chain
 item.battlegear2:quiver.name=Quiver
 
+item.battlegear2:mb.arrow.name=Arrow
 item.battlegear2:mb.arrow.ender.name=Ender Arrow
 item.battlegear2:mb.arrow.holy.name=Holy Torch Arrow
 item.battlegear2:mb.arrow.ice.name=Ice Packed Arrow
@@ -85,6 +86,7 @@ enchantment.shield.recover=Shield Recovery
 enchantment.bow.loot=Bow Luck
 enchantment.bow.charge=Bow Drawnback
 
+tile.battlegear2:flagpole.name=Flag Pole
 tile.battlegear2:flagpole.oak.name=Oak Flag Pole
 tile.battlegear2:flagpole.spruce.name=Spruce Flag Pole
 tile.battlegear2:flagpole.birch.name=Birch Flag Pole


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.